### PR TITLE
fixed a bug in 'parameters' argument in 'from_file' and 'from_file_using_temporary_files'

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -598,6 +598,10 @@ class AudioSegment(object):
             "-f", "wav"  # output options (filename last)
         ]
 
+        if parameters is not None:
+            # extend arguments with arbitrary set
+            conversion_command.extend(parameters)
+
         if start_second is not None:
             conversion_command += ["-ss", str(start_second)]
 
@@ -605,10 +609,6 @@ class AudioSegment(object):
             conversion_command += ["-t", str(duration)]
 
         conversion_command += [output.name]
-
-        if parameters is not None:
-            # extend arguments with arbitrary set
-            conversion_command.extend(parameters)
 
         log_conversion(conversion_command)
 
@@ -722,6 +722,10 @@ class AudioSegment(object):
             stdin_parameter = subprocess.PIPE
             stdin_data = file.read()
 
+        if parameters is not None:
+            # extend arguments with arbitrary set
+            conversion_command.extend(parameters)
+
         if codec:
             info = None
         else:
@@ -756,10 +760,6 @@ class AudioSegment(object):
             conversion_command += ["-t", str(duration)]
 
         conversion_command += ["-"]
-
-        if parameters is not None:
-            # extend arguments with arbitrary set
-            conversion_command.extend(parameters)
 
         log_conversion(conversion_command)
 


### PR DESCRIPTION
I was trying to read a very large MP4 file and convert to WAV so I provided some parameters to `from_file` in the argument `parameters` but It did not work.
My parameters were:
```python
parameters = ['-ac', '1', '-ar', '16000']
```

After investigation, I found that the `parameters` are added it the end of the command and the command will be something like:
```bash
ffmpeg -y -i my_video.mp4 -acodec pcm_s16le -vn -f wav - -ac 1 -ar 16000
```
I changed it to add `parameters` in the middle where the command should look like this:

```bash
ffmpeg -y -i my_video.mp4 -ac 1 -ar 16000 -acodec pcm_s16le -vn -f wav -
```
and it worked!!